### PR TITLE
Configure model tests

### DIFF
--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+  
   test "should get home" do
     get :index
     assert_response :success

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "the truth" do
+    assert true
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,6 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # Required for tests to use certain Devise helper like signed_in?
-  include Devise::TestHelpers
-
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 


### PR DESCRIPTION
- Devise TestHelpers break model tests, so only include them on controller tests that use is.
- Uncommented very basic model test.
